### PR TITLE
Running streaks

### DIFF
--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
@@ -31,6 +31,7 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
 
   override def reset(p: Puzzle): Unit = {
     puzzle = Some(p.norm)
+    streaks = streaks filter { case (user,_) => solvedList.map(_._2) contains user }
     solvedList = Seq()
   }
 

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
@@ -5,7 +5,7 @@ import NormMethods._
 import WordNormalizer._
 import StringNormalizer._
 
-case class SolutionResult(wordsAndSolvers: Map[Word, Seq[User]] = Map())
+case class SolutionResult(wordsAndSolvers: Map[Word, Seq[User]] = Map(), streaks: Map[User,Int] = Map())
 
 trait PuzzleSolution {
   def result: Option[SolutionResult]
@@ -18,6 +18,7 @@ trait PuzzleSolution {
 class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolution {
   val solutions: Map[String, Seq[String]] = dictionary.toSeq map (_.letters) groupBy sortByCodePoints
   var solvedList: Seq[(Word, User)] = Seq()
+  var streaks: Map[User,Int] = Map()
   var puzzle: Option[Puzzle] = None
 
   override def result: Option[SolutionResult] = {
@@ -25,7 +26,7 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
     val allSolutions: Seq[String] = puzzle map (p => solutions.getOrElse(sortByCodePoints(p.letters), Seq())) getOrElse(Seq())
     val allSolutionsMap: Map[Word, Seq[User]] = (allSolutions map (Word(_) -> Seq[User]())).toMap
     val resultMap = allSolutionsMap ++ (solvedList.distinct groupBy (_._1) mapValues (_.map(_._2)))
-    Some(SolutionResult(resultMap))
+    Some(SolutionResult(resultMap, streaks))
   }
 
   override def reset(p: Puzzle): Unit = {
@@ -36,7 +37,10 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
   override def noOfSolutions(puzzle: Puzzle): Int =
     solutions.getOrElse(sortByCodePoints(puzzle.norm.letters), Seq()).size
 
-  override def solved(user: User, word: Word): Unit = solvedList = solvedList :+ (word.norm, user)
+  override def solved(user: User, word: Word): Unit = {
+    streaks = streaks + (user -> ((streaks getOrElse (user, 0)) + (if (solvedList contains (word.norm, user)) 0 else 1)))
+    solvedList = solvedList :+ (word.norm, user)
+  }
 
   override def solutionId(word: Word): Option[Int] = {
     val allSolutionsForThisWord = solutions.getOrElse(sortByCodePoints(word.norm.letters), Seq())

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
@@ -6,11 +6,18 @@ object DisplayHelper {
   }
 
   implicit class SolutionResultDisplay(s: SolutionResult) {
-    def display: Seq[String] = s.wordsAndSolvers.map(kv => showWordAndSolution(kv._1, kv._2)) toSeq
+    def display: Seq[String] = {
+      val wordsAndSolvers = s.wordsAndSolvers.map(kv => showWordAndSolution(kv._1, kv._2))
+      val streaks = s.streaks.toList.filter(_._2 > 1).sortBy(-_._2).take(3).map(showStreak)
+
+      Seq("*Gårdagens lösningar:*") ++ wordsAndSolvers.toSeq ++ Seq("*Längsta obrutna serier:*") ++ streaks.toSeq
+    }
 
     private def showWordAndSolution(w: Word, solvers: Seq[User]): String = {
       s"*${w.letters}*: " ++ solvers.map(_.name).mkString(", ")
     }
+
+    private def showStreak(streak: (User, Int)): String = s"${streak._1.name}: ${streak._2}"
   }
 }
 
@@ -114,8 +121,7 @@ case class NewPuzzle(puzzle: Puzzle) extends Notification {
 }
 case class YesterdaysPuzzle(result: SolutionResult) extends Notification {
   override def toResponse: String = {
-    val lines = Seq("*Gårdagens lösningar:*") ++ result.display
-    lines mkString("\n")
+    result.display mkString("\n")
   }
 }
 case class MultipleSolutions(n: Int) extends Notification {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/DictionaryPuzzleSolutionSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/DictionaryPuzzleSolutionSpec.scala
@@ -57,7 +57,7 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
 
     solution.solved(User("foo"), Word("VANTRIVAS"))
 
-    solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo")))))
+    solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map(User("foo") -> 1)))
   }
 
   it should "return solutions in the order in which they are found" in {
@@ -69,7 +69,7 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
     solution.solved(User("baz"), Word("VANTRIVAS"))
 
     solution.result shouldBe
-      Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"), User("bar"), User("baz")))))
+      Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"), User("bar"), User("baz"))), Map(User("foo") -> 1, User("bar") -> 1, User("baz") -> 1)))
   }
 
   it should "only list one solution if a user solves the same word several times" in {
@@ -79,7 +79,7 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
     solution.solved(User("foo"), Word("VANTRIVAS"))
     solution.solved(User("foo"), Word("VANTRIVAS"))
 
-    solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo")))))
+    solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map(User("foo") -> 1)))
   }
 
   it should "forget solutions when a new puzzle is set" in {
@@ -91,7 +91,7 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
 
     solution.reset(Puzzle("VANTRIVAS"))
 
-    solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq())))
+    solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq()), Map(User("foo") -> 1, User("bar") -> 1)))
   }
 
   it should "normalize the puzzle on reset" in {
@@ -110,7 +110,7 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
     val word = Word("pikétröja")
     solution.solved(User("foo"), word)
 
-    solution.result shouldBe Some(SolutionResult(Map(word.norm -> Seq(User("foo")))))
+    solution.result shouldBe Some(SolutionResult(Map(word.norm -> Seq(User("foo"))), Map(User("foo") -> 1)))
   }
 
   it should "find a single solution even for a non-normalized puzzle" in {
@@ -134,7 +134,10 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
       Map(Word("DATORSPEL") -> Seq(User("foo"), User("bar")),
           Word("SPELDATOR") -> Seq(User("foo")),
           Word("LEDARPOST") -> Seq(User("baz")),
-          Word("REPSOLDAT") -> Seq())))
+          Word("REPSOLDAT") -> Seq()),
+      Map(User("foo") -> 2,
+          User("bar") -> 1,
+          User("baz") -> 1)))
   }
 
   it should "return the same solution id for a given word every time" in {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/DictionaryPuzzleSolutionSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/DictionaryPuzzleSolutionSpec.scala
@@ -84,14 +84,31 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
 
   it should "forget solutions when a new puzzle is set" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
+    solution.reset(Puzzle("GURKPUSSA"))
+    solution.solved(User("foo"), Word("PUSSGURKA"))
+    solution.solved(User("baz"), Word("PUSSGURKA"))
+
     solution.reset(Puzzle("DATORLESP")) //
 
     solution.solved(User("foo"), Word("DATORSPEL"))
     solution.solved(User("bar"), Word("DATORSPEL"))
 
+    solution.result shouldBe Some(SolutionResult(
+      Map(
+        Word("DATORSPEL") -> Seq(User("foo"), User("bar")),
+        Word("SPELDATOR") -> Seq(),
+        Word("REPSOLDAT") -> Seq(),
+        Word("LEDARPOST") -> Seq()
+      ),
+      Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
+    ))
+
     solution.reset(Puzzle("VANTRIVAS"))
 
-    solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq()), Map(User("foo") -> 1, User("bar") -> 1)))
+    solution.result shouldBe Some(SolutionResult(
+      Map(Word("VANTRIVAS") -> Seq()),
+      Map(User("foo") -> 2, User("bar") -> 1)
+    ))
   }
 
   it should "normalize the puzzle on reset" in {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
@@ -15,11 +15,17 @@ class ResponseSpec extends FlatSpec with Matchers {
     CorrectSolution(Word("DEF GHI")).toResponse should include ("DEF GHI är korrekt")
   }
 
-  "YesterdaysPuzzle" should "list all solutions and user names" in {
-    val solutionResult = SolutionResult(Map(
-      Word("ABCDEFGHI") -> Seq(User("foo"), User("bar")),
-      Word("DEFGHIABC") -> Seq(User("baz"))
-    ))
+  "YesterdaysPuzzle" should "list all solutions, user names and running streaks for users with streak > 1" in {
+    val solutionResult = SolutionResult(
+      Map(
+        Word("ABCDEFGHI") -> Seq(User("foo"), User("bar")),
+        Word("DEFGHIABC") -> Seq(User("baz"))
+      ),
+      Map(
+        User("foo") -> 1,
+        User("bar") -> 3,
+        User("baz") -> 2
+      ))
 
     val yesterdaysAsString = YesterdaysPuzzle(solutionResult).toResponse
 
@@ -27,6 +33,9 @@ class ResponseSpec extends FlatSpec with Matchers {
     yesterdaysAsString should include ("*DEFGHIABC*:")
     yesterdaysAsString should include ("foo, bar")
     yesterdaysAsString should include ("baz")
+    yesterdaysAsString should include ("bar: 3")
+    yesterdaysAsString should include ("baz: 2")
+    yesterdaysAsString should not include ("foo: 1")
   }
 
   "MultipleSolutions" should "show the number of solutions" in {


### PR DESCRIPTION
Niancat will now output the top 3 longest running streaks.

For days with multiple solutions, each solution is counted once towards the length of the streak, but streaks are only lost if the user does not find any solutions at all. In other words, if, in a single week, there are two solutions on Wednesday (and only one solution every other day), a user that finds all solutions will have a streak of 6 after solving Friday's puzzle, and a user that finds one but not both solutions on Wednesday will have a streak of 5.

The streaks are not displayed until the puzzle is reset.