### PR TITLE
Better streaks output

### DIFF
--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
@@ -174,7 +174,7 @@ class PuzzleEngine(val dictionary: Dictionary,
       val solutionId: Option[Int] = puzzleSolution.solutionId(word) filter(_ => noOfSolutions > 1)
       CompositeResponse(Vector(
         CorrectSolution(word),
-        SolutionNotification(user, solutionId)))
+        SolutionNotification(user, 1 + puzzleSolution.streak(user), solutionId)))
     } else {
       NotInTheDictionary(word)
     }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
@@ -13,6 +13,7 @@ trait PuzzleSolution {
   def noOfSolutions(puzzle: Puzzle): Int
   def solved(user: User, word: Word)
   def solutionId(word: Word): Option[Int]
+  def streak(user: User): Int
 }
 
 class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolution {
@@ -47,6 +48,8 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
     val allSolutionsForThisWord = solutions.getOrElse(sortByCodePoints(word.norm.letters), Seq())
     Some(allSolutionsForThisWord indexOf (word.norm.letters)) filter (_ != -1) map (_ + 1)
   }
+
+  override def streak(user: User): Int = streaks getOrElse (user, 0)
 
   private def sortByCodePoints(s: String): String = {
     val codePoints = s.codePoints() sorted() toArray

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
@@ -128,12 +128,13 @@ case class MultipleSolutions(n: Int) extends Notification {
   override def toResponse = s":bangbang: Dagens nian har $n lösningar. :bangbang:"
 }
 
-case class SolutionNotification(user: User, solutionId: Option[Int] = None) extends Notification {
+case class SolutionNotification(user: User, streak: Int, solutionId: Option[Int] = None) extends Notification {
   override def toResponse = {
     val parts = List(
-      Some(s":niancat: :niancat: :niancat: ${user.name} löste nian"),
-      solutionId map(n => s", ord $n"),
-      Some("! :niancat: :niancat: :niancat:")
+      Some(s"${user.name} löste nian"),
+      solutionId map (n => s", ord $n"),
+      Some("!"),
+      Some(" :niancat:" * streak)
     )
     parts.flatten.mkString
   }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
@@ -8,16 +8,16 @@ object DisplayHelper {
   implicit class SolutionResultDisplay(s: SolutionResult) {
     def display: Seq[String] = {
       val wordsAndSolvers = s.wordsAndSolvers.map(kv => showWordAndSolution(kv._1, kv._2))
-      val streaks = s.streaks.toList.filter(_._2 > 1).sortBy(-_._2).take(3).map(showStreak)
+      val streaks = s.streaks.toList.filter(_._2 > 1).groupBy(_._2).toList.map(showStreak)
 
-      Seq("*Gårdagens lösningar:*") ++ wordsAndSolvers.toSeq ++ Seq("*Längsta obrutna serier:*") ++ streaks.toSeq
+      Seq("*Gårdagens lösningar:*") ++ wordsAndSolvers.toSeq ++ Seq("*Obrutna serier:*") ++ streaks.toSeq
     }
 
     private def showWordAndSolution(w: Word, solvers: Seq[User]): String = {
       s"*${w.letters}*: " ++ solvers.map(_.name).mkString(", ")
     }
 
-    private def showStreak(streak: (User, Int)): String = s"${streak._1.name}: ${streak._2}"
+    private def showStreak(streak: (Int,Seq[(User,Int)])): String = s"${streak._1}: ${streak._2.map(_._1.name).mkString(", ")}"
   }
 }
 

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/PuzzleEngineSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/PuzzleEngineSpec.scala
@@ -341,6 +341,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     (puzzleSolution.solved _) expects(User("foo"), defaultWord)
     (puzzleSolution.noOfSolutions _) expects(*) returns (1) anyNumberOfTimes()
     (puzzleSolution.solutionId _) expects(*) returns(Some(1)) anyNumberOfTimes()
+    (puzzleSolution.streak _) expects(User("foo")) returns(1) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
@@ -422,7 +423,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val response = CheckSolution(defaultWord, User("foo"))(engine)
 
-    response should containResponse (SolutionNotification(User("foo"), None))
+    response should containResponse (SolutionNotification(User("foo"), 1, None))
   }
 
   it should "not include solution id in the solution notification is there is only one solution" in {
@@ -431,7 +432,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val response = CheckSolution(defaultWord, User("foo"))(engine)
 
-    response should containResponse (SolutionNotification(User("foo"), None))
+    response should containResponse (SolutionNotification(User("foo"), 1, None))
   }
 
   it should "include the solution if there are multiple solutions" in {
@@ -448,7 +449,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val response = CheckSolution(defaultWord, User("foo"))(engine)
 
-    response should containResponse (SolutionNotification(User("foo"), Some(solutionId)))
+    response should containResponse (SolutionNotification(User("foo"), 1, Some(solutionId)))
   }
 
   it should "not send a response when adding an unsolution" in {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
@@ -42,11 +42,15 @@ class ResponseSpec extends FlatSpec with Matchers {
   }
 
   "Solution notification" should "not include a solution id if not set" in {
-    SolutionNotification(User("foo"), None).toResponse should not (include ("ord "))
+    SolutionNotification(User("foo"), 1, None).toResponse should not (include ("ord "))
   }
 
   it should "include id if set" in {
-    SolutionNotification(User("foo"), Some(42)).toResponse should include ("ord 42")
+    SolutionNotification(User("foo"), 1, Some(42)).toResponse should include ("ord 42")
+  }
+
+  it should "repeat :niancat: as many times as the current streak" in {
+    SolutionNotification(User("foo"), 4, None).toResponse should include(":niancat: :niancat: :niancat: :niancat:")
   }
 
   "All unsolutions" should "contain the names of users and the texts" in {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
@@ -18,24 +18,23 @@ class ResponseSpec extends FlatSpec with Matchers {
   "YesterdaysPuzzle" should "list all solutions, user names and running streaks for users with streak > 1" in {
     val solutionResult = SolutionResult(
       Map(
-        Word("ABCDEFGHI") -> Seq(User("foo"), User("bar")),
+        Word("ABCDEFGHI") -> Seq(User("foo"), User("bar"), User("qux")),
         Word("DEFGHIABC") -> Seq(User("baz"))
       ),
       Map(
         User("foo") -> 1,
         User("bar") -> 3,
-        User("baz") -> 2
+        User("baz") -> 2,
+        User("qux") -> 2
       ))
 
     val yesterdaysAsString = YesterdaysPuzzle(solutionResult).toResponse
 
-    yesterdaysAsString should include ("*ABCDEFGHI*:")
-    yesterdaysAsString should include ("*DEFGHIABC*:")
-    yesterdaysAsString should include ("foo, bar")
-    yesterdaysAsString should include ("baz")
-    yesterdaysAsString should include ("bar: 3")
-    yesterdaysAsString should include ("baz: 2")
-    yesterdaysAsString should not include ("foo: 1")
+    yesterdaysAsString should include ("*ABCDEFGHI*: foo, bar, qux")
+    yesterdaysAsString should include ("*DEFGHIABC*: baz")
+    yesterdaysAsString should include ("3: bar")
+    yesterdaysAsString should include ("2: baz, qux")
+    yesterdaysAsString should not include ("1: foo")
   }
 
   "MultipleSolutions" should "show the number of solutions" in {


### PR DESCRIPTION
This groups streak output by streak length and outputs all streaks longer than 1, instead of showing just the top 3 users (with random tie breaks).

> *Obrutna serier:*
> 17423458291: sandell
> 4: f00ale, taschan, erike, emlun
> etc

It will also, when a user solves a puzzle, tweak the notification to be

> f00ale löste nian! :niancat: :niancat: :niancat: :niancat:

or

> sandell löste nian! :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat: :niancat:

etc, depending on how long the current streak is.