### PR TITLE
Count streaks only on weekdays

### DIFF
--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/NiancatService.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/NiancatService.scala
@@ -6,6 +6,8 @@ import org.http4s.dsl._
 import org.http4s.circe._
 import io.circe.generic.auto._
 
+import java.time.{LocalDate, DayOfWeek}
+
 case class SetPuzzleBody(puzzle: String)
 case class CheckSolutionBody(user: String, solution: String)
 case class AddUnsolutionBody(unsolution: String)
@@ -18,24 +20,38 @@ object NiancatService {
 
     HttpService {
 
-      case GET -> Root / "v1" / "puzzle"  => {
+      case GET -> Root / "v1" / "puzzle" => {
         val command = Get()
         val response = command(engine)
         val messageResponses = responder.messageResponses(response)
         Ok(Json.fromValues(messageResponses map (_.toJSON)))
       }
       case req @ POST -> Root / "v1" / "puzzle" => {
+        val yesterdayWasWeeekday = List(
+            DayOfWeek.TUESDAY,
+            DayOfWeek.WEDNESDAY,
+            DayOfWeek.THURSDAY,
+            DayOfWeek.FRIDAY,
+            DayOfWeek.SATURDAY
+          ) contains LocalDate.now().getDayOfWeek()
+
         req.as(jsonOf[SetPuzzleBody]) flatMap { setPuzzleBody =>
-          val isWeekday = true
-          val command = SetPuzzle(Puzzle(setPuzzleBody.puzzle), isWeekday)
+          val command = SetPuzzle(Puzzle(setPuzzleBody.puzzle), yesterdayWasWeeekday)
           val response = command(engine)
           val messageResponses = responder.messageResponses(response)
           Ok(Json.fromValues(messageResponses map (_.toJSON)))
         }
       }
       case req @ POST -> Root / "v1" / "solution" => {
+        val isWeekday = List(
+          DayOfWeek.MONDAY,
+          DayOfWeek.TUESDAY,
+          DayOfWeek.WEDNESDAY,
+          DayOfWeek.THURSDAY,
+          DayOfWeek.FRIDAY
+        ) contains LocalDate.now().getDayOfWeek()
+
         req.as(jsonOf[CheckSolutionBody]) flatMap { checkSolutionBody =>
-          val isWeekday = true
           val command = CheckSolution(Word(checkSolutionBody.solution), User(checkSolutionBody.user), isWeekday)
           val response = command(engine)
           val messageResponses = responder.messageResponses(response)
@@ -64,5 +80,4 @@ object NiancatService {
       }
     }
   }
-
 }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/NiancatService.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/NiancatService.scala
@@ -26,7 +26,8 @@ object NiancatService {
       }
       case req @ POST -> Root / "v1" / "puzzle" => {
         req.as(jsonOf[SetPuzzleBody]) flatMap { setPuzzleBody =>
-          val command = SetPuzzle(Puzzle(setPuzzleBody.puzzle))
+          val isWeekday = true
+          val command = SetPuzzle(Puzzle(setPuzzleBody.puzzle), isWeekday)
           val response = command(engine)
           val messageResponses = responder.messageResponses(response)
           Ok(Json.fromValues(messageResponses map (_.toJSON)))
@@ -34,7 +35,8 @@ object NiancatService {
       }
       case req @ POST -> Root / "v1" / "solution" => {
         req.as(jsonOf[CheckSolutionBody]) flatMap { checkSolutionBody =>
-          val command = CheckSolution(Word(checkSolutionBody.solution), User(checkSolutionBody.user))
+          val isWeekday = true
+          val command = CheckSolution(Word(checkSolutionBody.solution), User(checkSolutionBody.user), isWeekday)
           val response = command(engine)
           val messageResponses = responder.messageResponses(response)
           Ok(Json.fromValues(messageResponses map (_.toJSON)))

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Parser.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Parser.scala
@@ -5,9 +5,9 @@ sealed trait PuzzleCommand {
   def apply(engine: PuzzleEngine): Response
 }
 
-case class SetPuzzle(puzzle: Puzzle) extends PuzzleCommand {
+case class SetPuzzle(puzzle: Puzzle, isWeekday: Boolean) extends PuzzleCommand {
   def apply(engine: PuzzleEngine): Response = {
-    engine.set(puzzle)
+    engine.set(puzzle, isWeekday)
   }
 }
 
@@ -15,9 +15,9 @@ case class Get() extends PuzzleCommand {
   def apply(engine: PuzzleEngine): Response = engine.get()
 }
 
-case class CheckSolution(word: Word, user: User) extends PuzzleCommand {
+case class CheckSolution(word: Word, user: User, isWeekday: Boolean) extends PuzzleCommand {
   def apply(engine: PuzzleEngine): Response = {
-    engine.check(user, word)
+    engine.check(user, word, isWeekday)
   }
 }
 
@@ -45,13 +45,13 @@ case class PrivateChannel() extends ChannelVisibility
 case class PublicChannel() extends ChannelVisibility
 
 trait Parser {
-  def parse(msg: String, user: User, visibility: ChannelVisibility): PuzzleCommand
+  def parse(msg: String, user: User, visibility: ChannelVisibility, isWeekday: Boolean): PuzzleCommand
 }
 
 class SlackParser extends Parser {
-  def parse(msg: String, user: User, visibility: ChannelVisibility): PuzzleCommand = {
+  def parse(msg: String, user: User, visibility: ChannelVisibility, isWeekday: Boolean): PuzzleCommand = {
     if (!msg.startsWith("!")) {
-      if (visibility == PrivateChannel()) return CheckSolution(Word(msg), user)
+      if (visibility == PrivateChannel()) return CheckSolution(Word(msg), user, isWeekday)
 
       return Ignored()
     }
@@ -63,7 +63,7 @@ class SlackParser extends Parser {
 
     if (words(0) == "!sättnian") {
       if (words.size != 2) return InvalidCommand(msg, WrongArguments(words.size - 1, 1))
-      return SetPuzzle(Puzzle(words(1)))
+      return SetPuzzle(Puzzle(words(1)), isWeekday)
     }
 
     if (words(0) == "!olösning") {

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
@@ -174,7 +174,7 @@ class PuzzleEngine(val dictionary: Dictionary,
       val solutionId: Option[Int] = puzzleSolution.solutionId(word) filter(_ => noOfSolutions > 1)
       CompositeResponse(Vector(
         CorrectSolution(word),
-        SolutionNotification(user, solutionId)))
+        SolutionNotification(user, 1 + puzzleSolution.streak(user), solutionId)))
     } else {
       NotInTheDictionary(word)
     }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
@@ -172,9 +172,12 @@ class PuzzleEngine(val dictionary: Dictionary,
       puzzleSolution.solved(user, word)
       val noOfSolutions = puzzleSolution.noOfSolutions(puzzle)
       val solutionId: Option[Int] = puzzleSolution.solutionId(word) filter(_ => noOfSolutions > 1)
-      CompositeResponse(Vector(
-        CorrectSolution(word),
-        SolutionNotification(user, 1 + puzzleSolution.streak(user), solutionId)))
+      if (! puzzleSolution.hasSolved(user, word))
+        CompositeResponse(Vector(
+          CorrectSolution(word),
+          SolutionNotification(user, 1 + puzzleSolution.streak(user), solutionId)))
+      else
+        CorrectSolution(word)
     } else {
       NotInTheDictionary(word)
     }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
@@ -54,7 +54,7 @@ class PuzzleEngine(val dictionary: Dictionary,
   val unconfirmedUnsolutions: mutable.Map[User, String] = mutable.Map()
   val unsolutions: mutable.Map[User, List[String]] = mutable.Map()
 
-  def set(nonNormalizedPuzzle: Puzzle): Response = {
+  def set(nonNormalizedPuzzle: Puzzle, isWeekday: Boolean): Response = {
     val p = nonNormalizedPuzzle.norm
     if (puzzle.map(_ matches p) getOrElse false) {
       return SamePuzzle(p)
@@ -78,7 +78,7 @@ class PuzzleEngine(val dictionary: Dictionary,
       maybeUnsolutions map (AllUnsolutions(_))
     )
 
-    puzzleSolution.reset(p)
+    puzzleSolution.reset(p, isWeekday)
     unsolutions.clear()
     unconfirmedUnsolutions.clear()
 
@@ -92,10 +92,10 @@ class PuzzleEngine(val dictionary: Dictionary,
     }
   }
 
-  def check(user: User, word: Word): Response = {
+  def check(user: User, word: Word, isWeekday: Boolean): Response = {
     puzzle match {
       case None => NoPuzzleSet()
-      case Some(p: Puzzle) => checkSolution(user, word, p)
+      case Some(p: Puzzle) => checkSolution(user, word, p, isWeekday)
     }
   }
 
@@ -154,7 +154,7 @@ class PuzzleEngine(val dictionary: Dictionary,
     unconfirmedUnsolutions.remove(user)
   }
 
-  private def checkSolution(user: User, word: Word, puzzle: Puzzle): Response = {
+  private def checkSolution(user: User, word: Word, puzzle: Puzzle, isWeekday: Boolean): Response = {
     import WritingSystemHelper._
 
     if (!(word isNineLetters)) {
@@ -169,7 +169,7 @@ class PuzzleEngine(val dictionary: Dictionary,
       return WordAndPuzzleMismatch(word, puzzle, tooMany, tooFew)
     }
     if (dictionary has word) {
-      puzzleSolution.solved(user, word)
+      puzzleSolution.solved(user, word, isWeekday)
       val noOfSolutions = puzzleSolution.noOfSolutions(puzzle)
       val solutionId: Option[Int] = puzzleSolution.solutionId(word) filter(_ => noOfSolutions > 1)
       if (! puzzleSolution.hasSolved(user, word))

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
@@ -12,6 +12,7 @@ trait PuzzleSolution {
   def reset(puzzle: Puzzle)
   def noOfSolutions(puzzle: Puzzle): Int
   def solved(user: User, word: Word)
+  def hasSolved(user: User, word: Word): Boolean
   def solutionId(word: Word): Option[Int]
   def streak(user: User): Int
 }
@@ -42,6 +43,10 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
   override def solved(user: User, word: Word): Unit = {
     streaks = streaks + (user -> ((streaks getOrElse (user, 0)) + (if (solvedList contains (word.norm, user)) 0 else 1)))
     solvedList = solvedList :+ (word.norm, user)
+  }
+
+  override def hasSolved(user: User, word: Word): Boolean = {
+    solvedList contains (word.norm, user)
   }
 
   override def solutionId(word: Word): Option[Int] = {

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
@@ -33,7 +33,9 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
 
   override def reset(p: Puzzle, isWeekday: Boolean): Unit = {
     puzzle = Some(p.norm)
-    streaks = streaks filter { case (user,_) => solvedList.map(_._2) contains user }
+    if (isWeekday) {
+      streaks = streaks filter { case (user, _) => solvedList.map(_._2) contains user }
+    }
     solvedList = Seq()
   }
 
@@ -41,7 +43,10 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
     solutions.getOrElse(sortByCodePoints(puzzle.norm.letters), Seq()).size
 
   override def solved(user: User, word: Word, isWeekday: Boolean): Unit = {
-    streaks = streaks + (user -> ((streaks getOrElse (user, 0)) + (if (solvedList contains (word.norm, user)) 0 else 1)))
+    val userHasFoundThisSolutionBefore = solvedList contains (word.norm, user)
+    if (!userHasFoundThisSolutionBefore && isWeekday) {
+      streaks = streaks + (user -> ((streaks getOrElse (user, 0)) + 1))
+    }
     solvedList = solvedList :+ (word.norm, user)
   }
 

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
@@ -9,9 +9,9 @@ case class SolutionResult(wordsAndSolvers: Map[Word, Seq[User]] = Map(), streaks
 
 trait PuzzleSolution {
   def result: Option[SolutionResult]
-  def reset(puzzle: Puzzle)
+  def reset(puzzle: Puzzle, isWeekday: Boolean)
   def noOfSolutions(puzzle: Puzzle): Int
-  def solved(user: User, word: Word)
+  def solved(user: User, word: Word, isWeekday: Boolean)
   def hasSolved(user: User, word: Word): Boolean
   def solutionId(word: Word): Option[Int]
   def streak(user: User): Int
@@ -31,7 +31,7 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
     Some(SolutionResult(resultMap, streaks))
   }
 
-  override def reset(p: Puzzle): Unit = {
+  override def reset(p: Puzzle, isWeekday: Boolean): Unit = {
     puzzle = Some(p.norm)
     streaks = streaks filter { case (user,_) => solvedList.map(_._2) contains user }
     solvedList = Seq()
@@ -40,7 +40,7 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
   override def noOfSolutions(puzzle: Puzzle): Int =
     solutions.getOrElse(sortByCodePoints(puzzle.norm.letters), Seq()).size
 
-  override def solved(user: User, word: Word): Unit = {
+  override def solved(user: User, word: Word, isWeekday: Boolean): Unit = {
     streaks = streaks + (user -> ((streaks getOrElse (user, 0)) + (if (solvedList contains (word.norm, user)) 0 else 1)))
     solvedList = solvedList :+ (word.norm, user)
   }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleSolution.scala
@@ -13,6 +13,7 @@ trait PuzzleSolution {
   def noOfSolutions(puzzle: Puzzle): Int
   def solved(user: User, word: Word)
   def solutionId(word: Word): Option[Int]
+  def streak(user: User): Int
 }
 
 class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolution {
@@ -47,6 +48,8 @@ class DictionaryPuzzleSolution(val dictionary: Dictionary) extends PuzzleSolutio
     val allSolutionsForThisWord = solutions.getOrElse(sortByCodePoints(word.norm.letters), Seq())
     Some(allSolutionsForThisWord indexOf (word.norm.letters)) filter (_ != -1) map (_ + 1)
   }
+
+  override def streak(user: User): Int = streaks getOrElse (user, 0)
 
   private def sortByCodePoints(s: String): String = {
     val codePoints = s.codePoints() sorted() toArray

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
@@ -128,12 +128,13 @@ case class MultipleSolutions(n: Int) extends Notification {
   override def toResponse = s":bangbang: Dagens nian har $n lösningar. :bangbang:"
 }
 
-case class SolutionNotification(user: User, solutionId: Option[Int] = None) extends Notification {
+case class SolutionNotification(user: User, streak: Int, solutionId: Option[Int] = None) extends Notification {
   override def toResponse = {
     val parts = List(
-      Some(s":niancat: :niancat: :niancat: ${user.name} löste nian"),
-      solutionId map(n => s", ord $n"),
-      Some("! :niancat: :niancat: :niancat:")
+      Some(s"${user.name} löste nian"),
+      solutionId map (n => s", ord $n"),
+      Some("!"),
+      Some(" :niancat:" * streak)
     )
     parts.flatten.mkString
   }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
@@ -8,16 +8,16 @@ object DisplayHelper {
   implicit class SolutionResultDisplay(s: SolutionResult) {
     def display: Seq[String] = {
       val wordsAndSolvers = s.wordsAndSolvers.map(kv => showWordAndSolution(kv._1, kv._2))
-      val streaks = s.streaks.toList.filter(_._2 > 1).sortBy(-_._2).take(3).map(showStreak)
+      val streaks = s.streaks.toList.filter(_._2 > 1).groupBy(_._2).toList.map(showStreak)
 
-      Seq("*Gårdagens lösningar:*") ++ wordsAndSolvers.toSeq ++ Seq("*Längsta obrutna serier:*") ++ streaks.toSeq
+      Seq("*Gårdagens lösningar:*") ++ wordsAndSolvers.toSeq ++ Seq("*Obrutna serier:*") ++ streaks.toSeq
     }
 
     private def showWordAndSolution(w: Word, solvers: Seq[User]): String = {
       s"*${w.letters}*: " ++ solvers.map(_.name).mkString(", ")
     }
 
-    private def showStreak(streak: (User, Int)): String = s"${streak._1.name}: ${streak._2}"
+    private def showStreak(streak: (Int,Seq[(User,Int)])): String = s"${streak._1}: ${streak._2.map(_._1.name).mkString(", ")}"
   }
 }
 

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/DictionaryPuzzleSolutionSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/DictionaryPuzzleSolutionSpec.scala
@@ -53,20 +53,20 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
 
   "a DictionaryPuzzleSolution with a puzzle set" should "store a solution" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("TRIVASVAN")) // VANTRIVAS
+    solution.reset(Puzzle("TRIVASVAN"), true) // VANTRIVAS
 
-    solution.solved(User("foo"), Word("VANTRIVAS"))
+    solution.solved(User("foo"), Word("VANTRIVAS"), true)
 
     solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map(User("foo") -> 1)))
   }
 
   it should "return solutions in the order in which they are found" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("TRIVASVAN")) // VANTRIVAS
+    solution.reset(Puzzle("TRIVASVAN"), true) // VANTRIVAS
 
-    solution.solved(User("foo"), Word("VANTRIVAS"))
-    solution.solved(User("bar"), Word("VANTRIVAS"))
-    solution.solved(User("baz"), Word("VANTRIVAS"))
+    solution.solved(User("foo"), Word("VANTRIVAS"), true)
+    solution.solved(User("bar"), Word("VANTRIVAS"), true)
+    solution.solved(User("baz"), Word("VANTRIVAS"), true)
 
     solution.result shouldBe
       Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"), User("bar"), User("baz"))), Map(User("foo") -> 1, User("bar") -> 1, User("baz") -> 1)))
@@ -74,48 +74,52 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
 
   it should "only list one solution if a user solves the same word several times" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("TRIVASVAN")) // VANTRIVAS
+    solution.reset(Puzzle("TRIVASVAN"), true) // VANTRIVAS
 
-    solution.solved(User("foo"), Word("VANTRIVAS"))
-    solution.solved(User("foo"), Word("VANTRIVAS"))
+    solution.solved(User("foo"), Word("VANTRIVAS"), true)
+    solution.solved(User("foo"), Word("VANTRIVAS"), true)
 
     solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map(User("foo") -> 1)))
   }
 
   it should "forget solutions when a new puzzle is set" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("GURKPUSSA"))
-    solution.solved(User("foo"), Word("PUSSGURKA"))
-    solution.solved(User("baz"), Word("PUSSGURKA"))
+    solution.reset(Puzzle("GURKPUSSA"), true)
+    solution.solved(User("foo"), Word("PUSSGURKA"), true)
+    solution.solved(User("baz"), Word("PUSSGURKA"), true)
 
-    solution.reset(Puzzle("DATORLESP")) //
+    solution.reset(Puzzle("DATORLESP"), true)
 
-    solution.solved(User("foo"), Word("DATORSPEL"))
-    solution.solved(User("bar"), Word("DATORSPEL"))
+    solution.solved(User("foo"), Word("DATORSPEL"), true)
+    solution.solved(User("bar"), Word("DATORSPEL"), true)
 
-    solution.result shouldBe Some(SolutionResult(
-      Map(
-        Word("DATORSPEL") -> Seq(User("foo"), User("bar")),
-        Word("SPELDATOR") -> Seq(),
-        Word("REPSOLDAT") -> Seq(),
-        Word("LEDARPOST") -> Seq()
-      ),
-      Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
-    ))
+    solution.result shouldBe Some(
+      SolutionResult(
+        Map(
+          Word("DATORSPEL") -> Seq(User("foo"), User("bar")),
+          Word("SPELDATOR") -> Seq(),
+          Word("REPSOLDAT") -> Seq(),
+          Word("LEDARPOST") -> Seq()
+        ),
+        Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
+      )
+    )
 
-    solution.reset(Puzzle("VANTRIVAS"))
+    solution.reset(Puzzle("VANTRIVAS"), true)
 
-    solution.result shouldBe Some(SolutionResult(
-      Map(Word("VANTRIVAS") -> Seq()),
-      Map(User("foo") -> 2, User("bar") -> 1)
-    ))
+    solution.result shouldBe Some(
+      SolutionResult(
+        Map(Word("VANTRIVAS") -> Seq()),
+        Map(User("foo") -> 2, User("bar") -> 1)
+      )
+    )
   }
 
   it should "normalize the puzzle on reset" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
     val puzzle = Puzzle("piketröja")
 
-    solution.reset(puzzle)
+    solution.reset(puzzle, true)
 
     solution.puzzle shouldBe Some(puzzle.norm)
   }
@@ -123,9 +127,9 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
   it should "normalize words that users solve" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
 
-    solution.reset(Puzzle("PIKÉTRÖJA"))
+    solution.reset(Puzzle("PIKÉTRÖJA"), true)
     val word = Word("pikétröja")
-    solution.solved(User("foo"), word)
+    solution.solved(User("foo"), word, true)
 
     solution.result shouldBe Some(SolutionResult(Map(word.norm -> Seq(User("foo"))), Map(User("foo") -> 1)))
   }
@@ -133,19 +137,19 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
   it should "find a single solution even for a non-normalized puzzle" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
 
-    solution.reset(Puzzle("PIKÉTRÖJA"))
+    solution.reset(Puzzle("PIKÉTRÖJA"), true)
 
     solution.noOfSolutions(Puzzle("piketröja")) shouldBe 1
   }
 
   "a DictionaryPuzzleSolution with several solutions" should "return all of them" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("DATORLESP")) // DATORSPEL, SPELDATOR, LEDARPOST, REPSOLDAT
+    solution.reset(Puzzle("DATORLESP"), true) // DATORSPEL, SPELDATOR, LEDARPOST, REPSOLDAT
 
-    solution.solved(User("foo"), Word("DATORSPEL"))
-    solution.solved(User("bar"), Word("DATORSPEL"))
-    solution.solved(User("foo"), Word("SPELDATOR"))
-    solution.solved(User("baz"), Word("LEDARPOST"))
+    solution.solved(User("foo"), Word("DATORSPEL"), true)
+    solution.solved(User("bar"), Word("DATORSPEL"), true)
+    solution.solved(User("foo"), Word("SPELDATOR"), true)
+    solution.solved(User("baz"), Word("LEDARPOST"), true)
 
     solution.result shouldBe Some(SolutionResult(
       Map(Word("DATORSPEL") -> Seq(User("foo"), User("bar")),
@@ -159,7 +163,7 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
 
   it should "return the same solution id for a given word every time" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("DATORLESP")) // DATORSPEL, SPELDATOR, LEDARPOST, REPSOLDAT
+    solution.reset(Puzzle("DATORLESP"), true) // DATORSPEL, SPELDATOR, LEDARPOST, REPSOLDAT
     val word = Word("DATORSPEL")
 
     val solutionIds = 1 until 10 map (_ => solution.solutionId(word))
@@ -170,7 +174,7 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
 
   it should "return solution ids 1-4 in some order, if it has four solutions" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("DATORLESP")) // DATORSPEL, SPELDATOR, LEDARPOST, REPSOLDAT
+    solution.reset(Puzzle("DATORLESP"), true) // DATORSPEL, SPELDATOR, LEDARPOST, REPSOLDAT
 
     val words = List(Word("DATORSPEL"), Word("SPELDATOR"), Word("LEDARPOST"), Word("REPSOLDAT"))
     val solutionIds = words map (solution.solutionId(_)) flatten
@@ -180,14 +184,14 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
 
   it should "return the solution id even if there is only one solution" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("VANTRIVSA")) // VANTRIVAS
+    solution.reset(Puzzle("VANTRIVSA"), true) // VANTRIVAS
 
     solution.solutionId(Word("VANTRIVAS")) shouldBe Some(1)
   }
 
   it should "normalize words to find the solution id" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
-    solution.reset(Puzzle("PIKÉTRÖAJ")) // PIKÉTRÖJA
+    solution.reset(Puzzle("PIKÉTRÖAJ"), true) // PIKÉTRÖJA
 
     solution.solutionId(Word("piketröja")) shouldBe Some(1)
   }

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/DictionaryPuzzleSolutionSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/DictionaryPuzzleSolutionSpec.scala
@@ -60,6 +60,15 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
     solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map(User("foo") -> 1)))
   }
 
+  it should "not increase streak on weekends" in {
+    val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
+    solution.reset(Puzzle("TRIVASVAN"), true) // VANTRIVAS
+
+    solution.solved(User("foo"), Word("VANTRIVAS"), false)
+
+    solution.result shouldBe Some(SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map()))
+  }
+
   it should "return solutions in the order in which they are found" in {
     val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
     solution.reset(Puzzle("TRIVASVAN"), true) // VANTRIVAS
@@ -111,6 +120,39 @@ class DictionaryPuzzleSolutionSpec extends FlatSpec with Matchers with MockFacto
       SolutionResult(
         Map(Word("VANTRIVAS") -> Seq()),
         Map(User("foo") -> 2, User("bar") -> 1)
+      )
+    )
+  }
+
+  it should "not forget streaks when new puzzle is set on weekends" in {
+    val solution = new DictionaryPuzzleSolution(defaultDictionaryStub)
+    solution.reset(Puzzle("GURKPUSSA"), true)
+    solution.solved(User("foo"), Word("PUSSGURKA"), true)
+    solution.solved(User("baz"), Word("PUSSGURKA"), true)
+
+    solution.reset(Puzzle("DATORLESP"), true)
+
+    solution.solved(User("foo"), Word("DATORSPEL"), true)
+    solution.solved(User("bar"), Word("DATORSPEL"), true)
+
+    solution.result shouldBe Some(
+      SolutionResult(
+        Map(
+          Word("DATORSPEL") -> Seq(User("foo"), User("bar")),
+          Word("SPELDATOR") -> Seq(),
+          Word("REPSOLDAT") -> Seq(),
+          Word("LEDARPOST") -> Seq()
+        ),
+        Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
+      )
+    )
+
+    solution.reset(Puzzle("VANTRIVAS"), false)
+
+    solution.result shouldBe Some(
+      SolutionResult(
+        Map(Word("VANTRIVAS") -> Seq()),
+        Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
       )
     )
   }

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ParserSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ParserSpec.scala
@@ -6,7 +6,7 @@ class ParserSpec extends FlatSpec with Matchers {
   "a Parser" should "create a get command from !nian" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!nian", User("whatever"), PublicChannel())
+    val command = parser.parse("!nian", User("whatever"), PublicChannel(), true)
 
     command shouldBe Get()
   }
@@ -14,7 +14,7 @@ class ParserSpec extends FlatSpec with Matchers {
   it should "ignore non-command messages in public channels" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("Not a command", User("foo"), PublicChannel())
+    val command = parser.parse("Not a command", User("foo"), PublicChannel(), true)
 
     command shouldBe Ignored()
   }
@@ -23,23 +23,23 @@ class ParserSpec extends FlatSpec with Matchers {
     val parser = new SlackParser()
 
     val msg = "Not a command"
-    val command = parser.parse(msg, User("foo"), PrivateChannel())
+    val command = parser.parse(msg, User("foo"), PrivateChannel(), true)
 
-    command shouldBe CheckSolution(Word(msg), User("foo"))
+    command shouldBe CheckSolution(Word(msg), User("foo"), true)
   }
 
   it should "make a SetPuzzle command for !sättnian" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!sättnian ABCDEFGHI", User("foo"), PublicChannel())
+    val command = parser.parse("!sättnian ABCDEFGHI", User("foo"), PublicChannel(), true)
 
-    command shouldBe SetPuzzle(Puzzle("ABCDEFGHI"))
+    command shouldBe SetPuzzle(Puzzle("ABCDEFGHI"), true)
   }
 
   it should "respond with invalid command if it's unrecognized in private" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!notacommand", User("foo"), PrivateChannel())
+    val command = parser.parse("!notacommand", User("foo"), PrivateChannel(), true)
 
     command shouldBe InvalidCommand("!notacommand", UnknownCommand("!notacommand"))
   }
@@ -47,7 +47,7 @@ class ParserSpec extends FlatSpec with Matchers {
   it should "return invalid command, wrong no of args when !sättnian is called with zero args" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!sättnian", User("foo"), PublicChannel())
+    val command = parser.parse("!sättnian", User("foo"), PublicChannel(), true)
 
     val gotArgs = 0
     val expectedArgs = 1
@@ -57,7 +57,7 @@ class ParserSpec extends FlatSpec with Matchers {
   it should "ignore commands it doesn't understand when in public" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!notacommand", User("foo"), PublicChannel())
+    val command = parser.parse("!notacommand", User("foo"), PublicChannel(), true)
 
     command shouldBe Ignored()
   }
@@ -65,7 +65,7 @@ class ParserSpec extends FlatSpec with Matchers {
   it should "make an AddUnsolution for !olösning in public" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!olösning ABC DEF", User("foo"), PublicChannel())
+    val command = parser.parse("!olösning ABC DEF", User("foo"), PublicChannel(), true)
 
     command shouldBe AddUnsolution("ABC DEF", User("foo"))
   }
@@ -73,7 +73,7 @@ class ParserSpec extends FlatSpec with Matchers {
   it should "make AddUnsolution in private as well" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!olösning ABC DEF", User("foo"), PublicChannel())
+    val command = parser.parse("!olösning ABC DEF", User("foo"), PublicChannel(), true)
 
     command shouldBe AddUnsolution("ABC DEF", User("foo"))
   }
@@ -81,7 +81,7 @@ class ParserSpec extends FlatSpec with Matchers {
   it should "require an argument to !olösning" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!olösning", User("foo"), PrivateChannel())
+    val command = parser.parse("!olösning", User("foo"), PrivateChannel(), true)
 
     val gotArgs = 0
     val expectedArgs = 1
@@ -91,7 +91,7 @@ class ParserSpec extends FlatSpec with Matchers {
   it should "make ListUnsolutions from !olösningar in private" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!olösningar", User("foo"), PrivateChannel())
+    val command = parser.parse("!olösningar", User("foo"), PrivateChannel(), true)
 
     command shouldBe ListUnsolutions(User("foo"))
   }
@@ -99,7 +99,7 @@ class ParserSpec extends FlatSpec with Matchers {
   it should "ignore !olösningar in public" in {
     val parser = new SlackParser()
 
-    val command = parser.parse("!olösningar", User("foo"), PublicChannel())
+    val command = parser.parse("!olösningar", User("foo"), PublicChannel(), true)
 
     command shouldBe Ignored()
   }

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/PuzzleEngineSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/PuzzleEngineSpec.scala
@@ -70,9 +70,9 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
   def emptyPuzzleSolution: PuzzleSolution = {
     val puzzleSolution = stub[PuzzleSolution]
     (puzzleSolution.result _) when() returns(None) anyNumberOfTimes()
-    (puzzleSolution.reset _) when(*) anyNumberOfTimes()
+    (puzzleSolution.reset _) when(*, *) anyNumberOfTimes()
     (puzzleSolution.noOfSolutions _) when(*) returns(1) anyNumberOfTimes()
-    (puzzleSolution.solved _) when(*, *) anyNumberOfTimes()
+    (puzzleSolution.solved _) when(*, *, *) anyNumberOfTimes()
     (puzzleSolution.solutionId _) when (*) returns(Some(1)) anyNumberOfTimes()
 
     puzzleSolution
@@ -99,7 +99,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
   it should "notify that a new puzzle is set" in {
     val engine = makeAcceptingPuzzleEngine()
-    val response = SetPuzzle(defaultPuzzle)(engine)
+    val response = SetPuzzle(defaultPuzzle, true)(engine)
 
     response should containResponse (NewPuzzle(defaultPuzzle))
   }
@@ -107,14 +107,14 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
   it should "normalize the puzzle when notifying that a new one is set" in {
     val engine = makeAcceptingPuzzleEngine()
     val puzzle = Puzzle("pikétröja")
-    val response = SetPuzzle(puzzle)(engine)
+    val response = SetPuzzle(puzzle, true)(engine)
 
     response should containResponse (NewPuzzle(puzzle.norm))
   }
 
   it should "store the new puzzle" in {
     val engine = makeAcceptingPuzzleEngine()
-    SetPuzzle(defaultPuzzle)(engine)
+    SetPuzzle(defaultPuzzle, true)(engine)
 
     engine.puzzle shouldBe Some(defaultPuzzle)
   }
@@ -122,7 +122,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
   it should "normalize the puzzle when storing it" in {
     val engine = makeAcceptingPuzzleEngine()
     val puzzle = Puzzle("pikétröja")
-    SetPuzzle(puzzle)(engine)
+    SetPuzzle(puzzle, true)(engine)
 
     engine.puzzle shouldBe Some(puzzle.norm)
   }
@@ -130,7 +130,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
   it should "reply that no puzzle is set, when a user checks a solution" in {
     val engine = makeAcceptingPuzzleEngine()
 
-    val response = CheckSolution(defaultWord, User("foo"))(engine)
+    val response = CheckSolution(defaultWord, User("foo"), true)(engine)
 
     response shouldBe NoPuzzleSet()
   }
@@ -138,7 +138,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
   it should "not reply with a previous puzzle when a new one is set" in {
     val engine = makeAcceptingPuzzleEngine()
 
-    val response = SetPuzzle(defaultPuzzle)(engine)
+    val response = SetPuzzle(defaultPuzzle, true)(engine)
 
     response should not (containResponseOfType (classTag[YesterdaysPuzzle].runtimeClass))
   }
@@ -161,7 +161,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = rejectingDictionary
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle))
 
-    val response = CheckSolution(defaultWord, User("foo"))(engine)
+    val response = CheckSolution(defaultWord, User("foo"), true)(engine)
 
     response shouldBe NotInTheDictionary(defaultWord)
   }
@@ -170,7 +170,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = acceptingDictionary
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle))
 
-    val response = CheckSolution(defaultWord, User("foo"))(engine)
+    val response = CheckSolution(defaultWord, User("foo"), true)(engine)
 
     response should containResponse (CorrectSolution(defaultWord))
   }
@@ -180,7 +180,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle))
 
     val mismatchingWord = Word("NOTRIGHTX")
-    val response = CheckSolution(mismatchingWord, User("foo"))(engine)
+    val response = CheckSolution(mismatchingWord, User("foo"), true)(engine)
 
     response shouldBe a [WordAndPuzzleMismatch]
   }
@@ -191,7 +191,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = acceptingDictionary
     val engine = makePuzzleEngine(dictionary, Some(puzzle))
 
-    val response = CheckSolution(mismatchingWord, User("foo"))(engine)
+    val response = CheckSolution(mismatchingWord, User("foo"), true)(engine)
 
     response should have (
       'tooMany ("JKL"),
@@ -204,7 +204,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = acceptingDictionary
     val engine = makePuzzleEngine(dictionary, Some(puzzle))
 
-    val response = CheckSolution(mismatchingWord, User("foo"))(engine)
+    val response = CheckSolution(mismatchingWord, User("foo"), true)(engine)
 
     response should have (
       'tooMany ("AA"),
@@ -217,7 +217,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val engine = makePuzzleEngine(dictionary, Some(puzzle))
 
     val wordIsWrongLength = Word("ABCDEF")
-    val response = CheckSolution(wordIsWrongLength, User("foo"))(engine)
+    val response = CheckSolution(wordIsWrongLength, User("foo"), true)(engine)
 
     response shouldBe IncorrectLength(wordIsWrongLength, None, Some("GHI"))
   }
@@ -232,7 +232,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = SetPuzzle(Puzzle("ABCDEFGHI"))(engine)
+    val response = SetPuzzle(Puzzle("ABCDEFGHI"), true)(engine)
 
     response should containResponseOfType (classTag[YesterdaysPuzzle].runtimeClass)
   }
@@ -243,12 +243,12 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val puzzleSolution = mock[PuzzleSolution]
     (puzzleSolution.result _) expects() returning(Some(defaultSolutionResult)) anyNumberOfTimes()
-    (puzzleSolution.reset _) expects (newPuzzle)
+    (puzzleSolution.reset _) expects (newPuzzle, true)
     (puzzleSolution.noOfSolutions _) expects(*) returning(1) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    SetPuzzle(newPuzzle)(engine)
+    SetPuzzle(newPuzzle, true)(engine)
   }
 
   it should "respond that a puzzle is invalid if there are no solutions for it" in {
@@ -263,7 +263,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = SetPuzzle(invalidPuzzle)(engine)
+    val response = SetPuzzle(invalidPuzzle, true)(engine)
 
     response shouldBe InvalidPuzzle(invalidPuzzle)
   }
@@ -276,12 +276,12 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     // PuzzleSolution.result should be a non-mutable method, so it doesn't matter if
     // it's being called or not.
     (puzzleSolution.result _) expects() returning(Some(SolutionResult())) anyNumberOfTimes()
-    (puzzleSolution.reset _) expects(invalidPuzzle) never()
+    (puzzleSolution.reset _) expects(invalidPuzzle, true) never()
     (puzzleSolution.noOfSolutions _) expects(*) returning(0) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    SetPuzzle(invalidPuzzle)(engine)
+    SetPuzzle(invalidPuzzle, true)(engine)
   }
 
   it should "not set the puzzle if the puzzle has no solutions" in {
@@ -292,12 +292,12 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     // PuzzleSolution.result should be a non-mutable method, so it doesn't matter if
     // it's being called or not.
     (puzzleSolution.result _) expects() returning(Some(SolutionResult())) anyNumberOfTimes()
-    (puzzleSolution.reset _) expects(invalidPuzzle) never()
+    (puzzleSolution.reset _) expects(invalidPuzzle, true) never()
     (puzzleSolution.noOfSolutions _) expects(*) returning(0) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    SetPuzzle(invalidPuzzle)(engine)
+    SetPuzzle(invalidPuzzle, true)(engine)
 
     engine.puzzle shouldBe Some(defaultPuzzle)
   }
@@ -308,12 +308,12 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val puzzleSolution = stub[PuzzleSolution]
     (puzzleSolution.result _) when() returns(Some(defaultSolutionResult)) anyNumberOfTimes()
-    (puzzleSolution.reset _) when(*) anyNumberOfTimes()
+    (puzzleSolution.reset _) when(*, *) anyNumberOfTimes()
     (puzzleSolution.noOfSolutions _) when(newPuzzle) returning(7) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = SetPuzzle(newPuzzle)(engine)
+    val response = SetPuzzle(newPuzzle, true)(engine)
 
     response should containResponse (MultipleSolutions(7))
   }
@@ -324,12 +324,12 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val puzzleSolution = stub[PuzzleSolution]
     (puzzleSolution.result _) when() returns(Some(defaultSolutionResult)) anyNumberOfTimes()
-    (puzzleSolution.reset _) when(*) anyNumberOfTimes()
+    (puzzleSolution.reset _) when(*, *) anyNumberOfTimes()
     (puzzleSolution.noOfSolutions _) when(newPuzzle) returning(1) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = SetPuzzle(newPuzzle)(engine)
+    val response = SetPuzzle(newPuzzle, true)(engine)
 
     response should not (containResponseOfType (classTag[MultipleSolutions].runtimeClass))
   }
@@ -338,7 +338,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = acceptingDictionary
 
     val puzzleSolution = mock[PuzzleSolution]
-    (puzzleSolution.solved _) expects(User("foo"), defaultWord)
+    (puzzleSolution.solved _) expects(User("foo"), defaultWord, true)
     (puzzleSolution.noOfSolutions _) expects(*) returns (1) anyNumberOfTimes()
     (puzzleSolution.solutionId _) expects(*) returns(Some(1)) anyNumberOfTimes()
     (puzzleSolution.streak _) expects(User("foo")) returns(1) anyNumberOfTimes()
@@ -346,43 +346,43 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = CheckSolution(defaultWord, User("foo"))(engine)
+    val response = CheckSolution(defaultWord, User("foo"), true)(engine)
   }
 
   it should "not store an invalid solution" in {
     val dictionary = rejectingDictionary
 
     val puzzleSolution = mock[PuzzleSolution]
-    (puzzleSolution.solved _) expects(User("foo"), defaultWord) never()
+    (puzzleSolution.solved _) expects(User("foo"), defaultWord, true) never()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = CheckSolution(defaultWord, User("foo"))(engine)
+    val response = CheckSolution(defaultWord, User("foo"), true)(engine)
   }
 
   it should "not reset the puzzle if the new puzzle is the same as the old" in {
     val dictionary = acceptingDictionary
 
     val puzzleSolution = mock[PuzzleSolution]
-    (puzzleSolution.reset _) expects(*) never()
+    (puzzleSolution.reset _) expects(*, *) never()
     (puzzleSolution.noOfSolutions _) expects(*) never()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    SetPuzzle(defaultPuzzle)(engine)
+    SetPuzzle(defaultPuzzle, true)(engine)
   }
 
   it should "respond with SamePuzzle if the new puzzle is an anagram of the old" in {
     val dictionary = acceptingDictionary
 
     val puzzleSolution = stub[PuzzleSolution]
-    (puzzleSolution.reset _) when(*) anyNumberOfTimes()
+    (puzzleSolution.reset _) when(*, *) anyNumberOfTimes()
     (puzzleSolution.noOfSolutions _) when(*) returns(1) anyNumberOfTimes()
     (puzzleSolution.result _) when() returns(Some(SolutionResult())) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = SetPuzzle(shuffledPuzzle)(engine)
+    val response = SetPuzzle(shuffledPuzzle, true)(engine)
 
     response shouldBe SamePuzzle(shuffledPuzzle)
   }
@@ -391,13 +391,13 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = acceptingDictionary
 
     val puzzleSolution = stub[PuzzleSolution]
-    (puzzleSolution.reset _) when(*) anyNumberOfTimes()
+    (puzzleSolution.reset _) when(*, *) anyNumberOfTimes()
     (puzzleSolution.noOfSolutions _) when(*) returns(1) anyNumberOfTimes()
     (puzzleSolution.result _) when() returns(Some(SolutionResult())) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = SetPuzzle(defaultPuzzle)(engine)
+    val response = SetPuzzle(defaultPuzzle, true)(engine)
 
     response shouldBe SamePuzzle(defaultPuzzle)
   }
@@ -407,13 +407,13 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val puzzle = Puzzle("PIKETRÖJA")
 
     val puzzleSolution = stub[PuzzleSolution]
-    (puzzleSolution.reset _) when(*) anyNumberOfTimes()
+    (puzzleSolution.reset _) when(*, *) anyNumberOfTimes()
     (puzzleSolution.noOfSolutions _) when(*) returns(1) anyNumberOfTimes()
     (puzzleSolution.result _) when() returns(Some(SolutionResult())) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(puzzle), Some(puzzleSolution))
 
-    val response = SetPuzzle(Puzzle("pikétröja"))(engine)
+    val response = SetPuzzle(Puzzle("pikétröja"), true)(engine)
 
     response shouldBe SamePuzzle(puzzle)
   }
@@ -422,7 +422,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = acceptingDictionary
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle))
 
-    val response = CheckSolution(defaultWord, User("foo"))(engine)
+    val response = CheckSolution(defaultWord, User("foo"), true)(engine)
 
     response should containResponse (SolutionNotification(User("foo"), 1, None))
   }
@@ -431,9 +431,9 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = acceptingDictionary
     val puzzleSolution = stub[PuzzleSolution]
     (puzzleSolution.result _) when() returns(None) anyNumberOfTimes()
-    (puzzleSolution.reset _) when(*) anyNumberOfTimes()
+    (puzzleSolution.reset _) when(*, *) anyNumberOfTimes()
     (puzzleSolution.noOfSolutions _) when(*) returns(1) anyNumberOfTimes()
-    (puzzleSolution.solved _) when(*, *) anyNumberOfTimes()
+    (puzzleSolution.solved _) when(*, *, *) anyNumberOfTimes()
     (puzzleSolution.solutionId _) when (*) returns(Some(1)) anyNumberOfTimes()
     inSequence {
       (puzzleSolution.hasSolved _) when(*,*) returns(false) once()
@@ -442,12 +442,12 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val firstResponse = CheckSolution(defaultWord, User("foo"))(engine)
+    val firstResponse = CheckSolution(defaultWord, User("foo"), true)(engine)
 
     firstResponse should containResponse (CorrectSolution(defaultWord))
     firstResponse should containResponse (SolutionNotification(User("foo"), 1, None))
 
-    val secondResponse = CheckSolution(defaultWord, User("foo"))(engine)
+    val secondResponse = CheckSolution(defaultWord, User("foo"), true)(engine)
 
     secondResponse shouldBe CorrectSolution(defaultWord)
   }
@@ -456,7 +456,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = acceptingDictionary
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle))
 
-    val response = CheckSolution(defaultWord, User("foo"))(engine)
+    val response = CheckSolution(defaultWord, User("foo"), true)(engine)
 
     response should containResponse (SolutionNotification(User("foo"), 1, None))
   }
@@ -467,13 +467,13 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val puzzleSolution = stub[PuzzleSolution]
     (puzzleSolution.result _) when() returns(Some(defaultSolutionResult)) anyNumberOfTimes()
-    (puzzleSolution.reset _) when(*) anyNumberOfTimes()
+    (puzzleSolution.reset _) when(*, *) anyNumberOfTimes()
     (puzzleSolution.noOfSolutions _) when(*) returning(7) anyNumberOfTimes()
     (puzzleSolution.solutionId _) when(*) returning(Some(solutionId)) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
-    val response = CheckSolution(defaultWord, User("foo"))(engine)
+    val response = CheckSolution(defaultWord, User("foo"), true)(engine)
 
     response should containResponse (SolutionNotification(User("foo"), 1, Some(solutionId)))
   }
@@ -521,7 +521,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val engine = makeAcceptingPuzzleEngine(Some(defaultPuzzle))
 
     AddUnsolution(s"Some ${defaultPuzzle.letters}", User("foo"))(engine)
-    SetPuzzle(Puzzle("DATORSPEL"))(engine)
+    SetPuzzle(Puzzle("DATORSPEL"), true)(engine)
 
     val response = ListUnsolutions(User("foo"))(engine)
 
@@ -538,7 +538,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     AddUnsolution(textFoo2, User("foo"))(engine)
     AddUnsolution(textBar1, User("bar"))(engine)
 
-    val response = SetPuzzle(Puzzle("DATORSPEL"))(engine)
+    val response = SetPuzzle(Puzzle("DATORSPEL"), true)(engine)
 
     response should containResponse (AllUnsolutions(
       Map(User("foo") -> List(textFoo1, textFoo2),
@@ -548,7 +548,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
   it should "not mention unsolutions when a new puzzle is set, if there are no unsolutions" in {
     val engine = makeAcceptingPuzzleEngine(Some(defaultPuzzle))
 
-    val response = SetPuzzle(Puzzle("DATORSPEL"))(engine)
+    val response = SetPuzzle(Puzzle("DATORSPEL"), true)(engine)
 
     response shouldNot containResponseOfType(classTag[AllUnsolutions].runtimeClass)
   }

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/PuzzleEngineSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/PuzzleEngineSpec.scala
@@ -341,6 +341,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     (puzzleSolution.solved _) expects(User("foo"), defaultWord)
     (puzzleSolution.noOfSolutions _) expects(*) returns (1) anyNumberOfTimes()
     (puzzleSolution.solutionId _) expects(*) returns(Some(1)) anyNumberOfTimes()
+    (puzzleSolution.streak _) expects(User("foo")) returns(1) anyNumberOfTimes()
 
     val engine = makePuzzleEngine(dictionary, Some(defaultPuzzle), Some(puzzleSolution))
 
@@ -422,7 +423,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val response = CheckSolution(defaultWord, User("foo"))(engine)
 
-    response should containResponse (SolutionNotification(User("foo"), None))
+    response should containResponse (SolutionNotification(User("foo"), 1, None))
   }
 
   it should "not include solution id in the solution notification is there is only one solution" in {
@@ -431,7 +432,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val response = CheckSolution(defaultWord, User("foo"))(engine)
 
-    response should containResponse (SolutionNotification(User("foo"), None))
+    response should containResponse (SolutionNotification(User("foo"), 1, None))
   }
 
   it should "include the solution if there are multiple solutions" in {
@@ -448,7 +449,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
 
     val response = CheckSolution(defaultWord, User("foo"))(engine)
 
-    response should containResponse (SolutionNotification(User("foo"), Some(solutionId)))
+    response should containResponse (SolutionNotification(User("foo"), 1, Some(solutionId)))
   }
 
   it should "not send a response when adding an unsolution" in {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
@@ -42,11 +42,15 @@ class ResponseSpec extends FlatSpec with Matchers {
   }
 
   "Solution notification" should "not include a solution id if not set" in {
-    SolutionNotification(User("foo"), None).toResponse should not (include ("ord "))
+    SolutionNotification(User("foo"), 1, None).toResponse should not (include ("ord "))
   }
 
   it should "include id if set" in {
-    SolutionNotification(User("foo"), Some(42)).toResponse should include ("ord 42")
+    SolutionNotification(User("foo"), 1, Some(42)).toResponse should include ("ord 42")
+  }
+
+  it should "repeat :niancat: as many times as the current streak" in {
+    SolutionNotification(User("foo"), 4, None).toResponse should include(":niancat: :niancat: :niancat: :niancat:")
   }
 
   "All unsolutions" should "contain the names of users and the texts" in {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
@@ -18,24 +18,23 @@ class ResponseSpec extends FlatSpec with Matchers {
   "YesterdaysPuzzle" should "list all solutions, user names and running streaks for users with streak > 1" in {
     val solutionResult = SolutionResult(
       Map(
-        Word("ABCDEFGHI") -> Seq(User("foo"), User("bar")),
+        Word("ABCDEFGHI") -> Seq(User("foo"), User("bar"), User("qux")),
         Word("DEFGHIABC") -> Seq(User("baz"))
       ),
       Map(
         User("foo") -> 1,
         User("bar") -> 3,
-        User("baz") -> 2
+        User("baz") -> 2,
+        User("qux") -> 2
       ))
 
     val yesterdaysAsString = YesterdaysPuzzle(solutionResult).toResponse
 
-    yesterdaysAsString should include ("*ABCDEFGHI*:")
-    yesterdaysAsString should include ("*DEFGHIABC*:")
-    yesterdaysAsString should include ("foo, bar")
-    yesterdaysAsString should include ("baz")
-    yesterdaysAsString should include ("bar: 3")
-    yesterdaysAsString should include ("baz: 2")
-    yesterdaysAsString should not include ("foo: 1")
+    yesterdaysAsString should include ("*ABCDEFGHI*: foo, bar, qux")
+    yesterdaysAsString should include ("*DEFGHIABC*: baz")
+    yesterdaysAsString should include ("3: bar")
+    yesterdaysAsString should include ("2: baz, qux")
+    yesterdaysAsString should not include ("1: foo")
   }
 
   "MultipleSolutions" should "show the number of solutions" in {


### PR DESCRIPTION
This makes niancat ignore streaks on weekends.

That is, if it is Friday afternoon and a user has solved the puzzle on Wednesday, Thursday and Friday, their streak is currently 2 (because the streak is updated when the puzzle is reset). Come Saturday, when the puzzle is updated, the user's streak is pushed to 3 (because on Saturday, yesterday's puzzle was on a weekday), and the printout when Saturday's puzzle is announced states that the user has a current streak of 3.

Irregardless if the user solves the puzzle on Saturday, _nothing happens_ with the user's streak when the puzzle is reset on Sunday; it stays at 3 if the user solved the puzzle, and it stays at 3 if they didn't. The same thing applies when Monday's puzzle is posted; because _yesterday's_ puzzle was on a weekend, it doesn't count toward the streak.

If the user solves the Monday puzzle, their streak is incremented to 4 when Tuesday's puzzle is posted.