### PR TITLE
Persist to JSON state

### DIFF
--- a/niancat/build.sbt
+++ b/niancat/build.sbt
@@ -21,6 +21,7 @@ lazy val root = (project in file(".")).settings(
     "org.http4s" %% "http4s-circe" % Http4sVersion,
     "org.http4s" %% "http4s-dsl" % Http4sVersion,
     "ch.qos.logback" % "logback-classic" % "1.2.1",
-    "io.circe" %% "circe-generic" % "0.6.1"
+    "io.circe" %% "circe-generic" % "0.6.1",
+    "io.circe" %% "circe-parser" % "0.6.1"
   )
 )

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/NiancatService.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/NiancatService.scala
@@ -13,9 +13,8 @@ case class CheckSolutionBody(user: String, solution: String)
 case class AddUnsolutionBody(unsolution: String)
 
 object NiancatService {
-  def service(dictionary: Dictionary) = {
-    val state = new NiancatState()
-    val engine = new PuzzleEngine(state, dictionary)
+  def service(dictionary: Dictionary, stateRepr: StateRepr with StorableState) = {
+    val engine = new PuzzleEngine(new NiancatState(stateRepr), dictionary)
     val responder = new NiancatApiResponder()
 
     HttpService {
@@ -38,6 +37,7 @@ object NiancatService {
         req.as(jsonOf[SetPuzzleBody]) flatMap { setPuzzleBody =>
           val command = SetPuzzle(Puzzle(setPuzzleBody.puzzle), yesterdayWasWeeekday)
           val response = command(engine)
+          stateRepr.save()
           val messageResponses = responder.messageResponses(response)
           Ok(Json.fromValues(messageResponses map (_.toJSON)))
         }
@@ -54,6 +54,7 @@ object NiancatService {
         req.as(jsonOf[CheckSolutionBody]) flatMap { checkSolutionBody =>
           val command = CheckSolution(Word(checkSolutionBody.solution), User(checkSolutionBody.user), isWeekday)
           val response = command(engine)
+          stateRepr.save()
           val messageResponses = responder.messageResponses(response)
           Ok(Json.fromValues(messageResponses map (_.toJSON)))
         }
@@ -68,6 +69,7 @@ object NiancatService {
         req.as(jsonOf[AddUnsolutionBody]) flatMap { addUnsolutionBody =>
           val command = AddUnsolution(addUnsolutionBody.unsolution, User(user))
           val response = command(engine)
+          stateRepr.save()
           val messageResponses = responder.messageResponses(response)
           Ok(Json.fromValues(messageResponses map (_.toJSON)))
         }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Persistence.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Persistence.scala
@@ -1,0 +1,126 @@
+package io.github.dandeliondeathray.niancat
+
+import scala.util.Try
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser.decode
+import io.circe.generic.auto._
+import java.io.File
+import java.io.FileWriter
+import java.io.FileOutputStream
+import java.io.BufferedWriter
+import java.io.FileReader
+import java.io.BufferedReader
+import java.io.StringReader
+import java.nio.file.Files
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption._
+import java.nio.file.StandardOpenOption
+
+abstract trait StorableState {
+  def save(): Unit
+  def load(): Unit
+}
+
+class InMemoryState extends StateRepr with StorableState {
+  var puzzle: Option[Puzzle] = None
+  var unsolutions: Map[User, Seq[String]] = Map()
+  var unconfirmedUnsolutions: Map[User, String] = Map()
+  var solutions: Seq[(Word, User)] = Seq()
+  var streaks: Map[User, Int] = Map()
+  def save() = { /*noop*/ }
+  def load() = { /*noop*/ }
+}
+
+class JsonFileBackedState(val filePath: String) extends StateRepr with StorableState {
+  var puzzle: Option[Puzzle] = None
+  var unsolutions: Map[User, Seq[String]] = Map()
+  var unconfirmedUnsolutions: Map[User, String] = Map()
+  var solutions: Seq[(Word, User)] = Seq()
+  var streaks: Map[User, Int] = Map()
+
+  private def toStringMap[T](m: Map[User, T]): Map[String, T] = m map { case (k, v)   => k.name -> v }
+  private def fromStringMap[T](m: Map[String, T]): Map[User, T] = m map { case (k, v) => User(k) -> v }
+  implicit val stateEncoder: Encoder[JsonFileBackedState] = new Encoder[JsonFileBackedState] {
+    final def apply(s: JsonFileBackedState): Json = Json.obj(
+      ("puzzle", puzzle.asJson),
+      ("unsolutions", toStringMap(unsolutions).asJson),
+      ("unconfirmedUnsolutions", toStringMap(unconfirmedUnsolutions).asJson),
+      ("solutions", solutions.asJson),
+      ("streaks", toStringMap(streaks).asJson)
+    )
+  }
+
+  implicit val stateDecoder: Decoder[JsonFileBackedState] = new Decoder[JsonFileBackedState] {
+    final def apply(c: HCursor): Decoder.Result[JsonFileBackedState] = {
+      for {
+        pzzl <- c.downField("puzzle").as[Option[Puzzle]]
+        sltns <- c.downField("solutions").as[Seq[(Word, User)]]
+        nsltns <- c.downField("unsolutions").as[Map[String, Seq[String]]] map fromStringMap
+        ncnfrmdNslts <- c.downField("unconfirmedUnsolutions").as[Map[String, String]] map fromStringMap
+        strks <- c.downField("streaks").as[Map[String, Int]] map fromStringMap
+      } yield {
+        val state = new JsonFileBackedState(filePath)
+        state.puzzle = pzzl
+        state.solutions = sltns
+        state.unsolutions = nsltns
+        state.unconfirmedUnsolutions = ncnfrmdNslts
+        state.streaks = strks
+        state
+      }
+    }
+  }
+
+  def save(): Unit = {
+    val writer =
+      Files.newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8, CREATE, TRUNCATE_EXISTING)
+    writer.write(this.asJson.toString)
+    writer.flush()
+    writer.close()
+  }
+  def load(): Unit = {
+    Some(filePath)
+      .map(Paths.get(_))
+      .filter(Files.exists(_))
+      .map(path => new String(Files.readAllBytes(path), StandardCharsets.UTF_8))
+      .flatMap(read) match {
+      case Some(decoded) => apply(decoded)
+      case None          => backup(filePath)
+    }
+  }
+
+  private def read(json: String): Option[JsonFileBackedState] = {
+    decode[JsonFileBackedState](json) match {
+      case Left(ex) => {
+        println("ERROR: Parsing state file failed.")
+        println(s"STATE FILE CONTENTS:\n${json}")
+        println(ex)
+        None
+      }
+      case Right(state) => Some(state)
+    }
+  }
+  private def apply(decoded: JsonFileBackedState) = {
+    puzzle = decoded.puzzle
+    solutions = decoded.solutions
+    streaks = decoded.streaks
+    unsolutions = decoded.unsolutions
+    unconfirmedUnsolutions = decoded.unconfirmedUnsolutions
+  }
+  private def backup(filePath: String) = {
+    println(s"WARNING: File ${filePath} could not be parsed to a state; restarting with a blank slate.")
+    Try(if (Files.exists(Paths.get(filePath))) {
+      println(s"Moving ${filePath} to ${filePath}.bak to avoid overriding an old state...")
+      Files.move(Paths.get(filePath), Paths.get(s"${filePath}.bak"))
+      println("Previous state backed up.")
+    }).toEither match {
+      case Left(ex) => {
+        println("ERROR: Backup failed!")
+        println(ex)
+      }
+      case Right(_) => {}
+    }
+  }
+}


### PR DESCRIPTION
This enables snapshotting the current application state to a JSON file, pointed to by the `STATE_FILE` environment variable. The state is read on application start (on failure, a blank slate state is initialized), and written after operations that change it.