### PR TITLE
Decouple display of yesterdays solvers and running streaks

### DIFF
--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/NiancatState.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/NiancatState.scala
@@ -4,7 +4,7 @@ import org.scalactic.NormMethods._
 import PuzzleNormalizer._
 import WordNormalizer._
 
-case class SolutionResult(wordsAndSolvers: Map[Word, Seq[User]] = Map(), streaks: Map[User, Int] = Map())
+case class SolutionResult(wordsAndSolvers: Map[Word, Seq[User]] = Map())
 
 trait State {
   def puzzle(): Option[Puzzle]
@@ -16,6 +16,7 @@ trait State {
   def solved(user: User, word: Word, isWeekday: Boolean): Unit
   def hasSolved(user: User, word: Word): Boolean
   def streak(user: User): Int
+  def streaks(): Map[User, Int]
 
   def storeUnsolution(user: User, text: String)
   def storeUnconfirmedUnsolution(user: User, text: String)
@@ -42,9 +43,13 @@ class NiancatState(var repr: StateRepr) extends State {
       case Some(p) => {
         val allSolutionsMap: Map[Word, Seq[User]] = (allSolutions map (_ -> Seq[User]())).toMap
         val foundSolutions: Map[Word, Seq[User]] = (repr.solutions groupBy (_._1) mapValues (_.map(_._2).toSeq))
-        Some(SolutionResult(allSolutionsMap ++ foundSolutions, repr.streaks.toMap))
+        Some(SolutionResult(allSolutionsMap ++ foundSolutions))
       }
     }
+  }
+
+  override def streaks() = {
+    repr.streaks.toMap
   }
 
   override def reset(p: Puzzle, isWeekday: Boolean): Unit = {

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/PuzzleEngine.scala
@@ -45,14 +45,18 @@ class PuzzleEngine(val state: State, val dictionary: Dictionary) {
     val maybeUnsolutions = if (state unsolutions () isEmpty) None else Some(state unsolutions ())
 
     val allYesterdaysSolutions = findAllSolutions(state.puzzle)
+
+    val result = state.result(allYesterdaysSolutions)
+    state.reset(p, isWeekday)
+    val streaks = state.streaks()
+
     val responses: Vector[Option[Response]] = Vector(
       Some(NewPuzzle { p }),
-      state.result(allYesterdaysSolutions) map (YesterdaysPuzzle(_)),
+      result map YesterdaysPuzzle,
+      Some(Streaks(streaks)),
       Some(allSolutions.size) filter (_ > 1) map (MultipleSolutions(_)),
       maybeUnsolutions map (AllUnsolutions(_))
     )
-
-    state.reset(p, isWeekday)
 
     CompositeResponse(responses.flatten)
   }

--- a/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
+++ b/niancat/src/main/scala/io/github/dandeliondeathray/niancat/Response.scala
@@ -8,13 +8,18 @@ object DisplayHelper {
   implicit class SolutionResultDisplay(s: SolutionResult) {
     def display: Seq[String] = {
       val wordsAndSolvers = s.wordsAndSolvers.map(kv => showWordAndSolution(kv._1, kv._2))
-      val streaks = s.streaks.toList.filter(_._2 > 1).groupBy(_._2).toList.map(showStreak)
-
-      Seq("*Gårdagens lösningar:*") ++ wordsAndSolvers.toSeq ++ Seq("*Obrutna serier:*") ++ streaks.toSeq
+      Seq("*Gårdagens lösningar:*") ++ wordsAndSolvers.toSeq
     }
 
     private def showWordAndSolution(w: Word, solvers: Seq[User]): String = {
       s"*${w.letters}*: " ++ solvers.map(_.name).mkString(", ")
+    }
+  }
+
+  implicit class StreaksDisplay(s: Map[User, Int]) {
+    def display: Seq[String] = {
+      val streaks = s.toList.filter(_._2 > 1).groupBy(_._2).toList.sortBy(-_._1).map(showStreak)
+      if (streaks.nonEmpty) Seq("*Obrutna serier:*") ++ streaks.toSeq else Seq()
     }
 
     private def showStreak(streak: (Int, Seq[(User, Int)])): String =
@@ -123,6 +128,11 @@ case class NewPuzzle(puzzle: Puzzle) extends Notification {
 case class YesterdaysPuzzle(result: SolutionResult) extends Notification {
   override def toResponse: String = {
     result.display mkString ("\n")
+  }
+}
+case class Streaks(streaks: Map[User, Int]) extends Notification {
+  override def toResponse: String = {
+    streaks.display mkString ("\n")
   }
 }
 case class MultipleSolutions(n: Int) extends Notification {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/NiancatStateSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/NiancatStateSpec.scala
@@ -33,8 +33,9 @@ class NiancatStateSpec extends FlatSpec with Matchers with MockFactory {
     state.solved(User("foo"), Word("VANTRIVAS"), true)
 
     state.result(Seq(Word("VANTRIVAS"))) shouldBe Some(
-      SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map(User("foo") -> 1))
+      SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))))
     )
+    state.streaks() shouldBe Map(User("foo") -> 1)
   }
 
   it should "not increase streak on weekends" in {
@@ -44,8 +45,9 @@ class NiancatStateSpec extends FlatSpec with Matchers with MockFactory {
     state.solved(User("foo"), Word("VANTRIVAS"), false)
 
     state.result(Seq(Word("VANTRIVAS"))) shouldBe Some(
-      SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map())
+      SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))))
     )
+    state.streaks() shouldBe Map()
   }
 
   it should "return solutions in the order in which they are found" in {
@@ -59,10 +61,10 @@ class NiancatStateSpec extends FlatSpec with Matchers with MockFactory {
     state.result(Seq(Word("VANTRIVAS"))) shouldBe
       Some(
         SolutionResult(
-          Map(Word("VANTRIVAS") -> Seq(User("foo"), User("bar"), User("baz"))),
-          Map(User("foo") -> 1, User("bar") -> 1, User("baz") -> 1)
+          Map(Word("VANTRIVAS") -> Seq(User("foo"), User("bar"), User("baz")))
         )
       )
+    state.streaks() shouldBe Map(User("foo") -> 1, User("bar") -> 1, User("baz") -> 1)
   }
 
   it should "only list one solution if a user solves the same word several times" in {
@@ -73,8 +75,9 @@ class NiancatStateSpec extends FlatSpec with Matchers with MockFactory {
     state.solved(User("foo"), Word("VANTRIVAS"), true)
 
     state.result(Seq(Word("VANTRIVAS"))) shouldBe Some(
-      SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))), Map(User("foo") -> 1))
+      SolutionResult(Map(Word("VANTRIVAS") -> Seq(User("foo"))))
     )
+    state.streaks() shouldBe Map(User("foo") -> 1)
   }
 
   it should "forget solutions when a new puzzle is set" in {
@@ -95,19 +98,19 @@ class NiancatStateSpec extends FlatSpec with Matchers with MockFactory {
           Word("SPELDATOR") -> Seq(),
           Word("REPSOLDAT") -> Seq(),
           Word("LEDARPOST") -> Seq()
-        ),
-        Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
+        )
       )
     )
+    state.streaks() shouldBe Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
 
     state.reset(Puzzle("VANTRIVAS"), true)
 
     state.result(Seq(Word("VANTRIVAS"))) shouldBe Some(
       SolutionResult(
-        Map(Word("VANTRIVAS") -> Seq()),
-        Map(User("foo") -> 2, User("bar") -> 1)
+        Map(Word("VANTRIVAS") -> Seq())
       )
     )
+    state.streaks() shouldBe Map(User("foo") -> 2, User("bar") -> 1)
   }
 
   it should "not forget streaks when new puzzle is set on weekends" in {
@@ -128,19 +131,19 @@ class NiancatStateSpec extends FlatSpec with Matchers with MockFactory {
           Word("SPELDATOR") -> Seq(),
           Word("REPSOLDAT") -> Seq(),
           Word("LEDARPOST") -> Seq()
-        ),
-        Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
+        )
       )
     )
+    state.streaks() shouldBe Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
 
     state.reset(Puzzle("VANTRIVAS"), false)
 
     state.result(Seq(Word("VANTRIVAS"))) shouldBe Some(
       SolutionResult(
-        Map(Word("VANTRIVAS") -> Seq()),
-        Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
+        Map(Word("VANTRIVAS") -> Seq())
       )
     )
+    state.streaks() shouldBe Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
   }
 
   it should "normalize the puzzle on reset" in {
@@ -160,8 +163,9 @@ class NiancatStateSpec extends FlatSpec with Matchers with MockFactory {
     state.solved(User("foo"), word, true)
 
     state.result(Seq(Word("PIKÉTRÖJA").norm)) shouldBe Some(
-      SolutionResult(Map(word.norm -> Seq(User("foo"))), Map(User("foo") -> 1))
+      SolutionResult(Map(word.norm -> Seq(User("foo"))))
     )
+    state.streaks() shouldBe Map(User("foo") -> 1)
   }
 
   "a state with several solutions" should "return all of them" in {
@@ -180,10 +184,10 @@ class NiancatStateSpec extends FlatSpec with Matchers with MockFactory {
           Word("SPELDATOR") -> Seq(User("foo")),
           Word("LEDARPOST") -> Seq(User("baz")),
           Word("REPSOLDAT") -> Seq()
-        ),
-        Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
+        )
       )
     )
+    state.streaks() shouldBe Map(User("foo") -> 2, User("bar") -> 1, User("baz") -> 1)
   }
 
   it should "forget any unconfirmed unsolution when setting an unsolution for the same user" in {

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/PuzzleEngineSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/PuzzleEngineSpec.scala
@@ -92,6 +92,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     def storeUnconfirmedUnsolution(user: User, text: String): Unit = ()
     def storeUnsolution(user: User, text: String): Unit = ()
     def streak(user: User): Int = 0
+    def streaks(): Map[User, Int] = Map()
     def unsolutions(): Map[User, Seq[String]] = Map()
     def unconfirmedUnsolutions(): Map[User, String] = Map()
     def hasSolved(user: User, word: Word): Boolean = false
@@ -229,10 +230,10 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     val dictionary = stub[Dictionary]
     (dictionary.has _) when (*) returns (true) anyNumberOfTimes ()
     (dictionary.solutions _) when (Puzzle("DATORSPLE")) returns (Seq(
-      Word("DATORSPEL"),
+      Word("DATORSPEL")
     )) anyNumberOfTimes ()
     (dictionary.solutions _) when (Puzzle("VANTRIVSA")) returns (Seq(
-      Word("VANTRIVAS"),
+      Word("VANTRIVAS")
     )) anyNumberOfTimes ()
     (dictionary.solutionId _) when (*, *) returns (Some(1)) anyNumberOfTimes ()
 
@@ -242,7 +243,9 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     SetPuzzle(Puzzle("DATORSPLE"), true)(engine)
     val response = SetPuzzle(Puzzle("VANTRIVSA"), true)(engine).asInstanceOf[CompositeResponse]
 
-    val maybeYesterdaysPuzzle: Option[YesterdaysPuzzle] = response.responses.collectFirst({ case x: YesterdaysPuzzle => x })
+    val maybeYesterdaysPuzzle: Option[YesterdaysPuzzle] = response.responses.collectFirst({
+      case x: YesterdaysPuzzle => x
+    })
 
     maybeYesterdaysPuzzle match {
       case Some(YesterdaysPuzzle(solutionResult)) =>
@@ -260,6 +263,7 @@ class PuzzleEngineSpec extends FlatSpec with Matchers with MockFactory with Resp
     (state.result _) expects (*) returning (Some(defaultSolutionResult)) anyNumberOfTimes ()
     (state.reset _) expects (newPuzzle, true)
     (state.unsolutions _) expects () returning Map() anyNumberOfTimes ()
+    (state.streaks _) expects () returning Map() anyNumberOfTimes ()
 
     val engine = new PuzzleEngine(state, acceptingDictionary)
 

--- a/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
+++ b/niancat/src/test/scala/io/github/dandeliondeathray/niancat/ResponseSpec.scala
@@ -15,17 +15,11 @@ class ResponseSpec extends FlatSpec with Matchers {
     CorrectSolution(Word("DEF GHI")).toResponse should include("DEF GHI är korrekt")
   }
 
-  "YesterdaysPuzzle" should "list all solutions, user names and running streaks for users with streak > 1" in {
+  "YesterdaysPuzzle" should "list all solutions and user names" in {
     val solutionResult = SolutionResult(
       Map(
         Word("ABCDEFGHI") -> Seq(User("foo"), User("bar"), User("qux")),
         Word("DEFGHIABC") -> Seq(User("baz"))
-      ),
-      Map(
-        User("foo") -> 1,
-        User("bar") -> 3,
-        User("baz") -> 2,
-        User("qux") -> 2
       )
     )
 
@@ -33,9 +27,22 @@ class ResponseSpec extends FlatSpec with Matchers {
 
     yesterdaysAsString should include("*ABCDEFGHI*: foo, bar, qux")
     yesterdaysAsString should include("*DEFGHIABC*: baz")
-    yesterdaysAsString should include("3: bar")
-    yesterdaysAsString should include("2: baz, qux")
-    yesterdaysAsString should not include ("1: foo")
+  }
+
+  "Streaks" should "list all solvers and their streak count" in {
+    val streaks = Map(
+      User("foo") -> 1,
+      User("oof") -> 1,
+      User("bar") -> 3,
+      User("baz") -> 2,
+      User("qux") -> 2
+    )
+
+    val streaksAsString = Streaks(streaks).toResponse
+
+    streaksAsString should include("3: bar")
+    streaksAsString should include("2: qux, baz")
+    streaksAsString should not include ("1:")
   }
 
   "MultipleSolutions" should "show the number of solutions" in {


### PR DESCRIPTION
This (hopefully) solves the annoying bug with the streaks being displayed before the state update has been applied.